### PR TITLE
Add slurmdash link, fix all buttons

### DIFF
--- a/docs/cluster/access/mobaxterm.md
+++ b/docs/cluster/access/mobaxterm.md
@@ -6,7 +6,7 @@ MobaXterm is a full-featured login tool for Windows users. It features a pseudo-
 
 MobaXterm is available at the link below. Select the Installer version and proceed with normal Windows style install. Select the Portable version if you want to run without installing.
 
-[Download MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html){:target="_blank" .md-button .md-button--primary }
+[Download MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html){ .md-button .md-button--primary target="_blank" rel="noopener" }
 
 If you downloaded the portable version, make sure to save it in a place that is easy to access and will not be deleted.
 

--- a/docs/cluster/access/ondemand.md
+++ b/docs/cluster/access/ondemand.md
@@ -37,7 +37,7 @@ Open OnDemand includes a command-line terminal app that connects you to the HPC 
 
 The **Files** menu contains links to common storage locations. Clicking one of the file links opens the **File Explorer** in a new browser tab.
 
-| Button      | Function                             |
+| Button | Function |
 | ----------- | ------------------------------------ |
 | `Open in Terminal` | Open current directory in a terminal window in a new browser tab |
 | `New File` | Create a new, empty file |

--- a/docs/cluster/access/putty.md
+++ b/docs/cluster/access/putty.md
@@ -6,7 +6,7 @@ PuTTY is a lightweight SSH client for Windows users. It features session and pro
 
 PuTTY is available at the link below. For Windows installation, select the **MSI (Windows Installer)** 64-bit x86 version and proceed with install. If you prefer not to install, download the **putty.exe** 64-bit x86 version in the **Alternative binary section**.
 
-[Download PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html){:target="_blank" .md-button .md-button--primary }
+[Download PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html){ .md-button .md-button--primary target="_blank" rel="noopener" }
 
 If you downloaded the no install version, make sure to save it in a place that is easy to access and will not be deleted.
 

--- a/docs/cluster/accounts.md
+++ b/docs/cluster/accounts.md
@@ -5,7 +5,7 @@ A user account is required for access to Research Computing resources, including
 !!! info "PI eligibility"
     Research Computing follows MCW policy [RS.GN.160](https://infoscope.mcw.edu/Corporate-Policies/Principal-Investigator-Eligibility.htm){:target="_blank"} when determining PI eligibility.
 
-[Request an Account](https://forms.office.com/r/98QNm6cAyt){ :target="_blank" .md-button .md-button--primary }
+[Request an Account](https://forms.office.com/r/98QNm6cAyt){ .md-button .md-button--primary target="_blank" rel="noopener" }
 
 ## Terms of Use
 

--- a/docs/cluster/hardware.md
+++ b/docs/cluster/hardware.md
@@ -1,6 +1,8 @@
 # Overview
 
-The HPC environment became available to MCW researchers in March 2021. The cluster consists of **79** compute nodes, **4,200** CPU cores, and **96** GPUs. The cluster is connected by **7** 100 Gbps switches running RoCEv2 (ethernet equivalent to Infiniband). Additionally, a **780 TB** NVMe provides scratch storage, and a **2.6 PB** scale-out NAS provides persistent storage.
+The HPC environment became available to MCW researchers in March 2021. The cluster consists of **79** compute nodes, **4,200** CPU cores, and **96** GPUs. The cluster is connected by **7** 100 Gbps switches running RoCEv2 (ethernet equivalent to Infiniband). Additionally, a **780 TB** NVMe array provides scratch storage, and a **2.6 PB** scale-out NAS provides persistent storage.
+
+[Cluster Status](https://slurmdash.rcc.mcw.edu){ .md-button .md-button--primary target="_blank" rel="noopener" }
 
 ## Cluster
 

--- a/docs/secure-computing/project-account.md
+++ b/docs/secure-computing/project-account.md
@@ -27,4 +27,4 @@ We strongly suggest to email {{ support_email }} prior to requesting or signing 
 
 If you're ready to proceed, use the link below.
 
-[Request a ResHPC Project Account](https://forms.office.com/r/qVmFJrBzQr){:target="_blank" .md-button .md-button--primary }
+[Request a ResHPC Project Account](https://forms.office.com/r/qVmFJrBzQr){ .md-button .md-button--primary target="_blank" rel="noopener" }


### PR DESCRIPTION
Adding link to slurmdash on the hardware spec page. All buttons are now opening in new tabs as intended.